### PR TITLE
Periodically check inode numbers

### DIFF
--- a/follower/follower.go
+++ b/follower/follower.go
@@ -222,13 +222,18 @@ func (t *Follower) follow() error {
 		// stat the file, if it's still there, just continue and try to read bytes
 		// if not, go through our re-opening routine
 		case <-time.After(10 * time.Second):
-			_, err := t.file.Stat()
-			if err == nil {
-				continue
+			fi1, err := t.file.Stat()
+			if err != nil && !os.IsNotExist(err) {
+				return err
 			}
 
-			if !os.IsNotExist(err) {
+			fi2, err := os.Stat(t.filename)
+			if err != nil && !os.IsNotExist(err) {
 				return err
+			}
+
+			if os.SameFile(fi1, fi2) {
+				continue
 			}
 
 			if err := t.rewatch(); err != nil {

--- a/follower/follower_test.go
+++ b/follower/follower_test.go
@@ -70,6 +70,20 @@ var (
 			"A lonely cab-horse steams and stamps.",
 			"And then the lighting of the lamps.",
 		},
+
+		{
+			"In Xanadu did Kubla Khan",
+			"A stately pleasure-dome decree:",
+			"Where Alph, the sacred river, ran",
+			"Through caverns measureless to man",
+			"   Down to a sunless sea.",
+			"So twice five miles of fertile ground",
+			"With walls and towers were girdled round;",
+			"And there were gardens bright with sinuous rills,",
+			"Where blossomed many an incense-bearing tree;",
+			"And here were forests ancient as the hills,",
+			"Enfolding sunny spots of greenery.",
+		},
 	}
 )
 
@@ -130,11 +144,11 @@ func TestTruncate(t *testing.T) {
 	}
 
 	// write a different set of lines
-	if err := writeLines(file2, testLines[1]); err != nil {
+	if err := writeLines(file2, testLines[2]); err != nil {
 		t.Fatal(err)
 	}
 
-	assertFollowedLines(t, f, testLines[1])
+	assertFollowedLines(t, f, testLines[2])
 }
 
 func TestRenameCreate(t *testing.T) {

--- a/follower/follower_test.go
+++ b/follower/follower_test.go
@@ -208,6 +208,7 @@ func TestSymlink(t *testing.T) {
 }
 
 func testFile(t *testing.T, name string) *os.File {
+	// open in append mode since most loggers will be doing such
 	file, err := os.OpenFile(path.Join(tmpDir, name), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		t.Fatal(err)
@@ -224,19 +225,9 @@ func testSymlink(t *testing.T, oldname, newname string) {
 }
 
 func testPair(t *testing.T, filename string) (*os.File, *Follower) {
-	file, err := os.Create(path.Join(tmpDir, filename))
-	if err != nil {
-		t.Fatal(err)
-	}
-	file.Close()
+	file := testFile(t, filename)
 
-	// re-open in append mode since most loggers will be doing such
-	file2, err := os.OpenFile(file.Name(), os.O_APPEND|os.O_WRONLY, 0666)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := New(file2.Name(), Config{
+	f, err := New(file.Name(), Config{
 		Reopen: true,
 		Offset: 0,
 		Whence: io.SeekEnd,
@@ -245,7 +236,7 @@ func testPair(t *testing.T, filename string) (*os.File, *Follower) {
 		t.Fatal(err)
 	}
 
-	return file2, f
+	return file, f
 }
 
 func writeLines(file *os.File, lines []string) error {


### PR DESCRIPTION
Use [File.Stat()](https://golang.org/pkg/os/#File.Stat), [os.Stat(name)](https://golang.org/pkg/os/#Stat), and [os.SameFile](https://golang.org/pkg/os/#SameFile) to periodically compare an idle file's inode number with whatever is currently assigned that filename.

This fixes two bugs related to log file rotation:

* Symbolic links. If a Follower is watching something via a symbolic link, and the link is modified to point to a new file, there's no indication from inotify.
* Potential race condition if a file is moved/renamed before inotify is ready.

Added a test to confirm that symbolic links are now handled properly.