### PR TITLE
Fix two goroutine leaks

### DIFF
--- a/follower/follower.go
+++ b/follower/follower.go
@@ -99,7 +99,7 @@ func (t *Follower) follow() error {
 
 	var (
 		eventChan = make(chan fsnotify.Event)
-		errChan   = make(chan error)
+		errChan   = make(chan error, 1)
 	)
 
 	t.watcher, err = fsnotify.NewWatcher()
@@ -290,9 +290,6 @@ func (t *Follower) sendLine(l []byte, d int) {
 }
 
 func (t *Follower) watchFileEvents(eventChan chan fsnotify.Event, errChan chan error) {
-	defer close(eventChan)
-	defer close(errChan)
-
 	for {
 		select {
 		case evt, ok := <-t.watcher.Events:
@@ -309,11 +306,16 @@ func (t *Follower) watchFileEvents(eventChan chan fsnotify.Event, errChan chan e
 				}
 
 			default:
-				eventChan <- evt
+				select {
+				case eventChan <- evt:
+				case err := <-t.watcher.Errors:
+					errChan <- err
+					return
+				}
 			}
 
 		// die on a file watching error
-		case err, _ := <-t.watcher.Errors:
+		case err := <-t.watcher.Errors:
 			errChan <- err
 			return
 		}

--- a/follower/follower_test.go
+++ b/follower/follower_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -91,6 +92,15 @@ func TestMain(m *testing.M) {
 	tmpDir, _ = ioutil.TempDir("", "fllw")
 	rs := m.Run()
 	os.RemoveAll(tmpDir)
+	if rs == 0 {
+		// Followers may take 10 seconds to notice the removal.
+		time.Sleep(10 * time.Second)
+		fmt.Println(runtime.NumGoroutine())
+		if runtime.NumGoroutine() > 2 {
+			// Heuristic to detect leaked goroutines.
+			rs = 1
+		}
+	}
 	os.Exit(rs)
 }
 

--- a/follower/follower_test.go
+++ b/follower/follower_test.go
@@ -99,7 +99,7 @@ func TestMain(m *testing.M) {
 			// Heuristic to detect leaked goroutines.
 			fmt.Println("--- FAIL: TestMain")
 			logger := log.New(os.Stdout, "\t", log.Lshortfile)
-			logger.Fatal("Possible goroutine leak")
+			logger.Fatal("possible goroutine leak")
 		}
 	}
 	os.Exit(rs)

--- a/follower/follower_test.go
+++ b/follower/follower_test.go
@@ -2,6 +2,7 @@ package follower
 
 import (
 	"fmt"
+	"log"
 	"io"
 	"io/ioutil"
 	"os"
@@ -17,7 +18,6 @@ import (
 var (
 	tmpDir string
 
-	_         = fmt.Print
 	testLines = [][]string{
 		{
 			"’Twas brillig, and the slithy toves",
@@ -97,7 +97,9 @@ func TestMain(m *testing.M) {
 		time.Sleep(10 * time.Second)
 		if runtime.NumGoroutine() > 2 {
 			// Heuristic to detect leaked goroutines.
-			rs = 1
+			fmt.Println("--- FAIL: TestMain")
+			logger := log.New(os.Stdout, "\t", log.Lshortfile)
+			logger.Fatal("Possible goroutine leak")
 		}
 	}
 	os.Exit(rs)

--- a/follower/follower_test.go
+++ b/follower/follower_test.go
@@ -95,7 +95,6 @@ func TestMain(m *testing.M) {
 	if rs == 0 {
 		// Followers may take 10 seconds to notice the removal.
 		time.Sleep(10 * time.Second)
-		fmt.Println(runtime.NumGoroutine())
 		if runtime.NumGoroutine() > 2 {
 			// Heuristic to detect leaked goroutines.
 			rs = 1


### PR DESCRIPTION
There were two possible goroutine leaks that could manifest during file rotation. Both in `watchFileEvents`:

* First, it could block writing the last event to `eventChan`, if the `follow` goroutine had ended. Fixed with a trigger `t.watcher.Errors`, which is closed during cleanup.
* Second, it could block writing to `errChan`, under similar circumstances. Fixed by adding a single-item buffer to the channel.

Closing `eventChan` and `errChan` was unnecessary and could've prevented a buffered `errChan` from ever being read, so I removed that too.

Added a test for goroutine leaks. It had to go in `TestMain`, in order to run after all of the other tests. It doesn't pass unless both fixes are in place.