### PR TITLE
Improving windows support

### DIFF
--- a/follower/follower_test.go
+++ b/follower/follower_test.go
@@ -2,9 +2,9 @@ package follower
 
 import (
 	"fmt"
-	"log"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
 	"runtime"
@@ -94,7 +94,7 @@ func TestMain(m *testing.M) {
 	os.RemoveAll(tmpDir)
 	if rs == 0 {
 		// Followers may take 10 seconds to notice the removal.
-		time.Sleep(10 * time.Second)
+		time.Sleep(11 * time.Second)
 		if runtime.NumGoroutine() > 2 {
 			// Heuristic to detect leaked goroutines.
 			fmt.Println("--- FAIL: TestMain")


### PR DESCRIPTION
* added removal of also \r when read line ends with \r\n
* changed the way files are open on windows. By default, golang on windows opens a file without FILE_SHARE_DELETE flag, what prevents
deleting a file when go-tail is reading it. Used elastic beats ReadOpen implementation of opening files.