### PR TITLE
Ensure we trap close and error channels

### DIFF
--- a/follower/follower.go
+++ b/follower/follower.go
@@ -156,13 +156,16 @@ func (t *Follower) follow() error {
 				// that we want to re-open the file and seek to the end
 				if err == io.EOF {
 					l := len(s)
+					if l == 0 {
+						<-time.NewTimer(time.Millisecond * 100).C
+					} else {
+						t.offset, err = t.file.Seek(-int64(l), io.SeekCurrent)
+						if err != nil {
+							return err
+						}
 
-					t.offset, err = t.file.Seek(-int64(l), io.SeekCurrent)
-					if err != nil {
-						return err
+						t.reader.Reset(t.file)
 					}
-
-					t.reader.Reset(t.file)
 					break
 				}
 

--- a/follower/follower.go
+++ b/follower/follower.go
@@ -158,14 +158,13 @@ func (t *Follower) follow() error {
 					l := len(s)
 					if l == 0 {
 						<-time.NewTimer(time.Millisecond * 100).C
-					} else {
-						t.offset, err = t.file.Seek(-int64(l), io.SeekCurrent)
-						if err != nil {
-							return err
-						}
-
-						t.reader.Reset(t.file)
+					} 
+					t.offset, err = t.file.Seek(-int64(l), io.SeekCurrent)
+					if err != nil {
+						return err
 					}
+
+					t.reader.Reset(t.file)
 					break
 				}
 

--- a/follower/follower.go
+++ b/follower/follower.go
@@ -187,7 +187,7 @@ func (t *Follower) follow() error {
 					if !os.IsNotExist(err) {
 						return err
 					}
-
+					<-time.NewTimer(time.Second * 10).C
 					// it's possible that an unlink can cause fsnotify.Chmod,
 					// so attempt to rewatch if the file is missing
 					if err := t.rewatch(); err != nil {

--- a/follower/follower.go
+++ b/follower/follower.go
@@ -114,47 +114,60 @@ func (t *Follower) follow() error {
 
 	for {
 		for {
-			// discard leading NUL bytes
-			var discarded int
+			select {
 
-			for {
-				b, _ := t.reader.Peek(peekSize)
-				i := bytes.LastIndexByte(b, '\x00')
-
-				if i > 0 {
-					n, _ := t.reader.Discard(i + 1)
-					discarded += n
-				}
-
-				if i+1 < peekSize {
-					break
-				}
-			}
-
-			s, err := t.reader.ReadBytes('\n')
-			if err != nil && err != io.EOF {
+			// any errors that come from fsnotify
+			case err := <-errChan:
 				return err
-			}
 
-			// if we encounter EOF before a line delimiter,
-			// ReadBytes() will return the remaining bytes,
-			// so push them back onto the buffer, rewind
-			// our seek position, and wait for further file changes.
-			// we also have to save our dangling byte count in the event
-			// that we want to re-open the file and seek to the end
-			if err == io.EOF {
-				l := len(s)
+			// a request to stop
+			case <-t.closeCh:
+				t.watcher.Remove(t.filename)
+				return nil
 
-				t.offset, err = t.file.Seek(-int64(l), io.SeekCurrent)
-				if err != nil {
+			default:
+				// discard leading NUL bytes
+				var discarded int
+
+				for {
+					b, _ := t.reader.Peek(peekSize)
+					i := bytes.LastIndexByte(b, '\x00')
+
+					if i > 0 {
+						n, _ := t.reader.Discard(i + 1)
+						discarded += n
+					}
+
+					if i+1 < peekSize {
+						break
+					}
+				}
+
+				s, err := t.reader.ReadBytes('\n')
+				if err != nil && err != io.EOF {
 					return err
 				}
 
-				t.reader.Reset(t.file)
-				break
-			}
+				// if we encounter EOF before a line delimiter,
+				// ReadBytes() will return the remaining bytes,
+				// so push them back onto the buffer, rewind
+				// our seek position, and wait for further file changes.
+				// we also have to save our dangling byte count in the event
+				// that we want to re-open the file and seek to the end
+				if err == io.EOF {
+					l := len(s)
 
-			t.sendLine(s, discarded)
+					t.offset, err = t.file.Seek(-int64(l), io.SeekCurrent)
+					if err != nil {
+						return err
+					}
+
+					t.reader.Reset(t.file)
+					break
+				}
+
+				t.sendLine(s, discarded)
+			}
 		}
 
 		// we're now at EOF, so wait for changes


### PR DESCRIPTION
This adds a select case statements to trap error and close channels during the initial read-through of the file (before waiting for changes).  If there is an error or a close is requested prior to this block finishing it would cause the caller to block on `.Close()` or cause parts of the internals here to block when sending to error.